### PR TITLE
Ravikishoreg patch 1

### DIFF
--- a/app.js
+++ b/app.js
@@ -571,12 +571,17 @@ function _runServer(argv) {
           forceAuthn: data.forceAuthn === 'true'
         };
         console.log('Received AuthnRequest => \n', req.authnRequest);
-      } else if(req.idp.options.allowRequestAcsUrl && req.idp.options.acsUrl && req.idp.options.acsUrl.contains("$"))
+      } else if(req.idp.options.allowRequestAcsUrl && req.idp.options.acsUrl && req.idp.options.acsUrl.includes("$"))
       {
         const evaluatedAcsUrl = eval(`${"\`"+req.idp.options.acsUrl+"\`"}`);
+        var evaluatedAudience;
+        if(req.idp.options.audience.includes("$")) {
+              evaluatedAudience = eval(`${"\`"+req.idp.options.audience+"\`"}`);
+        }
         req.authnRequest = {
           relayState: req.query.RelayState,
-          acsUrl: evaluatedAcsUrl
+          acsUrl: evaluatedAcsUrl,
+          audience: evaluatedAudience
         };
         console.log('Evaluated AuthnRequest => \n', req.authnRequest);
       }
@@ -673,6 +678,9 @@ function _runServer(argv) {
         }
         if (req.authnRequest.relayState) {
           authOptions.RelayState = req.authnRequest.relayState;
+        }
+        if (req.authnRequest.audience) {
+          authOptions.audience = req.authnRequest.audience;
         }
       } else {
         req.user[key] = req.body[key];

--- a/app.js
+++ b/app.js
@@ -652,7 +652,7 @@ function _runServer(argv) {
   });
 
   app.use(function(req, res, next){
-    req.user = argv.config.user;
+    req.user = extend({}, argv.config.user);    //dont reuse the user
     req.metadata = argv.config.metadata;
     req.idp = { options: idpOptions };
     req.participant = getParticipant(req);

--- a/app.js
+++ b/app.js
@@ -580,7 +580,7 @@ function _runServer(argv) {
                     evaluatedAudience = eval(`${"\`"+req.idp.options.audience+"\`"}`);
               }
               req.authnRequest = {
-                id: "dummyEvaluated",     #Without this, user view is not even rendering other params
+                id: "dummyEvaluated",     //Without this, user view is not even rendering other params
                 relayState: req.query.RelayState,
                 acsUrl: evaluatedAcsUrl,
                 audience: evaluatedAudience

--- a/app.js
+++ b/app.js
@@ -573,17 +573,21 @@ function _runServer(argv) {
         console.log('Received AuthnRequest => \n', req.authnRequest);
       } else if(req.idp.options.allowRequestAcsUrl && req.idp.options.acsUrl && req.idp.options.acsUrl.includes("$"))
       {
-        const evaluatedAcsUrl = eval(`${"\`"+req.idp.options.acsUrl+"\`"}`);
-        var evaluatedAudience;
-        if(req.idp.options.audience.includes("$")) {
-              evaluatedAudience = eval(`${"\`"+req.idp.options.audience+"\`"}`);
+        try {
+              const evaluatedAcsUrl = eval(`${"\`"+req.idp.options.acsUrl+"\`"}`);
+              var evaluatedAudience;
+              if(req.idp.options.audience.includes("$")) {
+                    evaluatedAudience = eval(`${"\`"+req.idp.options.audience+"\`"}`);
+              }
+              req.authnRequest = {
+                relayState: req.query.RelayState,
+                acsUrl: evaluatedAcsUrl,
+                audience: evaluatedAudience
+              };
+              console.log('Evaluated AuthnRequest => \n', req.authnRequest);
+        } catch(err) {
+              console.log('Evaluating ACS failed => \n', err);
         }
-        req.authnRequest = {
-          relayState: req.query.RelayState,
-          acsUrl: evaluatedAcsUrl,
-          audience: evaluatedAudience
-        };
-        console.log('Evaluated AuthnRequest => \n', req.authnRequest);
       }
       return showUser(req, res, next);
     })

--- a/app.js
+++ b/app.js
@@ -580,6 +580,7 @@ function _runServer(argv) {
                     evaluatedAudience = eval(`${"\`"+req.idp.options.audience+"\`"}`);
               }
               req.authnRequest = {
+                id: "dummyEvaluated",     #Without this, user view is not even rendering other params
                 relayState: req.query.RelayState,
                 acsUrl: evaluatedAcsUrl,
                 audience: evaluatedAudience
@@ -673,7 +674,8 @@ function _runServer(argv) {
         req.authnRequest = JSON.parse(buffer.toString('utf8'));
 
         // Apply AuthnRequest Params
-        authOptions.inResponseTo = req.authnRequest.id;
+        if(req.authnRequest.id != "dummyEvaluated")
+            authOptions.inResponseTo = req.authnRequest.id;
         if (req.idp.options.allowRequestAcsUrl && req.authnRequest.acsUrl) {
           authOptions.acsUrl = req.authnRequest.acsUrl;
           authOptions.recipient = req.authnRequest.acsUrl;

--- a/app.js
+++ b/app.js
@@ -571,6 +571,14 @@ function _runServer(argv) {
           forceAuthn: data.forceAuthn === 'true'
         };
         console.log('Received AuthnRequest => \n', req.authnRequest);
+      } else if(req.idp.options.allowRequestAcsUrl && req.idp.options.acsUrl && req.idp.options.acsUrl.contains("$"))
+      {
+        const evaluatedAcsUrl = eval(`${"\`"+req.idp.options.acsUrl+"\`"}`);
+        req.authnRequest = {
+          relayState: req.query.RelayState,
+          acsUrl: evaluatedAcsUrl
+        };
+        console.log('Evaluated AuthnRequest => \n', req.authnRequest);
       }
       return showUser(req, res, next);
     })


### PR DESCRIPTION
 Ability to have request based acs url

Useful mainly for idp based requests. A single idp server can serve multiple sp servers following similar acs url. For example if acsUrl while starting is 
${(new URL(req.headers.Referer)).origin}/saml/SSO

It will redirect to the referer site at saml/SSO endpoint